### PR TITLE
Remove extra `\\` at `load` string on `external-libraries.json` entries

### DIFF
--- a/external-libraries.json
+++ b/external-libraries.json
@@ -20,7 +20,7 @@
         "documentation": "https://tonejs.github.io/docs/14.7.77/index.html",
         "author": "Yotam Mann",
         "thumbnail": "tone-js.png",
-        "load": "await loadScript(\\\"https://unpkg.com/tone\\\")",
+        "load": "await loadScript(\"https://unpkg.com/tone\")",
         "examples": [
             "https://hydra.ojack.xyz/?code=YXdhaXQlMjBsb2FkU2NyaXB0KCUyMmh0dHBzJTNBJTJGJTJGdW5wa2cuY29tJTJGdG9uZSUyMiklMEElMEFzeW50aCUyMCUzRCUyMG5ldyUyMFRvbmUuU3ludGgoKS50b0Rlc3RpbmF0aW9uKCklM0IlMEFzeW50aC50cmlnZ2VyQXR0YWNrUmVsZWFzZSglMjJDNCUyMiUyQyUyMCUyMjhuJTIyKSUzQg%3D%3D",
             "https://hydra.ojack.xyz/?code=JTJGJTJGZWwlMjB0aWVtcG8lMjBkZWwlMjBhZ3VhJTBBJTJGJTJGZmxvciUyMGRlJTIwZnVlZ28lMEElMkYlMkZmbG9yZGVmdWVnby5naXRodWIuaW8lMEElMEFhd2FpdCUyMGxvYWRTY3JpcHQoJTIyaHR0cHMlM0ElMkYlMkZ1bnBrZy5jb20lMkZ0b25lJTIyKSUwQSUwQSUyRiUyRnNvdW5kJTIwZnJvbSUyMGh0dHBzJTNBJTJGJTJGZnJlZXNvdW5kLm9yZyUyRnBlb3BsZSUyRm11eTIxNDk5NzIlMkZzb3VuZHMlMkY1ODY0MjMlMkYlMEFjb25zdCUyMHBsYXllciUyMCUzRCUyMG5ldyUyMFRvbmUuUGxheWVyKCUyMmh0dHBzJTNBJTJGJTJGY2RuLmZyZWVzb3VuZC5vcmclMkZwcmV2aWV3cyUyRjU4NiUyRjU4NjQyM18xMjgzNDg1OS1scS5tcDMlMjIpLnRvRGVzdGluYXRpb24oKSUzQiUwQSUyRiUyRiUyMHBsYXklMjBhcyUyMHNvb24lMjBhcyUyMHRoZSUyMGJ1ZmZlciUyMGlzJTIwbG9hZGVkJTBBcGxheWVyLmF1dG9zdGFydCUyMCUzRCUyMHRydWUlM0IlMEElMEFvc2MoMTAlMkMtMC4xKS5ibGVuZChzb2xpZCgwJTJDMCUyQzEpJTJDMC4yKS5jb2xvcigwLjQlMkMwLjglMkMxKS5rYWxlaWQoOTk5KS5tb2R1bGF0ZShub2lzZSgxMDApJTJDMC4wMSkubW9kdWxhdGUobzApLm91dCgp"
@@ -33,7 +33,7 @@
         "www": "",
         "author": "mr.doob",
         "thumbnail": "three-js.png",
-        "load": "await loadScript(\\\"https://threejs.org/build/three.js\\\")",
+        "load": "await loadScript(\"https://threejs.org/build/three.js\")",
         "examples": [
            "https://hydra.ojack.xyz/?code=YXdhaXQlMjBsb2FkU2NyaXB0KCUyMmh0dHBzJTNBJTJGJTJGdGhyZWVqcy5vcmclMkZidWlsZCUyRnRocmVlLmpzJTIyKSUwQSUwQXNjZW5lJTIwJTNEJTIwbmV3JTIwVEhSRUUuU2NlbmUoKSUwQWNhbWVyYSUyMCUzRCUyMG5ldyUyMFRIUkVFLlBlcnNwZWN0aXZlQ2FtZXJhKDc1JTJDJTIwd2luZG93LmlubmVyV2lkdGglMjAlMkYlMjB3aW5kb3cuaW5uZXJIZWlnaHQlMkMlMjAwLjElMkMlMjAxMDAwKSUwQSUwQXJlbmRlcmVyJTIwJTNEJTIwbmV3JTIwVEhSRUUuV2ViR0xSZW5kZXJlcigpJTBBcmVuZGVyZXIuc2V0U2l6ZSh3aWR0aCUyQyUyMGhlaWdodCklMEFnZW9tZXRyeSUyMCUzRCUyMG5ldyUyMFRIUkVFLkJveEdlb21ldHJ5KCklMEFtYXRlcmlhbCUyMCUzRCUyMG5ldyUyMFRIUkVFLk1lc2hCYXNpY01hdGVyaWFsKCU3QmNvbG9yJTNBJTIwMHgwMGZmMDAlN0QpJTBBY3ViZSUyMCUzRCUyMG5ldyUyMFRIUkVFLk1lc2goZ2VvbWV0cnklMkMlMjBtYXRlcmlhbCklM0IlMEFzY2VuZS5hZGQoY3ViZSklMEFjYW1lcmEucG9zaXRpb24ueiUyMCUzRCUyMDEuNSUwQSUwQSUyRiUyRiUyMCd1cGRhdGUnJTIwaXMlMjBhJTIwcmVzZXJ2ZWQlMjBmdW5jdGlvbiUyMHRoYXQlMjB3aWxsJTIwYmUlMjBydW4lMjBldmVyeSUyMHRpbWUlMjB0aGUlMjBtYWluJTIwaHlkcmElMjByZW5kZXJpbmclMjBjb250ZXh0JTIwaXMlMjB1cGRhdGVkJTBBdXBkYXRlJTIwJTNEJTIwKCklMjAlM0QlM0UlMjAlN0IlMEElMjAlMjBjdWJlLnJvdGF0aW9uLnglMjAlMkIlM0QlMjAwLjAxJTNCJTBBJTIwJTIwY3ViZS5yb3RhdGlvbi55JTIwJTJCJTNEJTIwMC4wMSUzQiUwQSUyMCUyMHJlbmRlcmVyLnJlbmRlciglMjBzY2VuZSUyQyUyMGNhbWVyYSUyMCklM0IlMEElN0QlMEElMEFzMC5pbml0KCU3QiUyMHNyYyUzQSUyMHJlbmRlcmVyLmRvbUVsZW1lbnQlMjAlN0QpJTBBJTBBc3JjKHMwKS5yZXBlYXQoKS5vdXQoKSUwQSUwQQ%3D%3D"
         ]


### PR DESCRIPTION
There is an extra escaped `\` between the double quotes of the library URL, which when importing it, it inserts the code like this:

```javascript
await loadScript(\"https://threejs.org/build/three.js\")
```

instead of

```javascript
await loadScript("https://threejs.org/build/three.js")
```